### PR TITLE
Remove outdated TODO comment in firebaseStore.ts

### DIFF
--- a/src/stores/firebaseStore.ts
+++ b/src/stores/firebaseStore.ts
@@ -87,8 +87,6 @@ export const useFirebaseStore = defineStore('firebase', {
 				)
 				const projectSnapshot = await getDocs(projectQuery)
 
-				// TODO - find filter name
-				// Check for existing filter with same name (case-insensitive)
 				const existingDoc = projectSnapshot.docs.find(
 					(doc) => doc.data().stackName.toLowerCase() === nameLower
 				)


### PR DESCRIPTION
The TODO comment for checking existing filters was unnecessary as the logic is already implemented.

### Issue
Resolves #228 